### PR TITLE
RabbitMQ timeout feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	usage := `zabbix-agent-extension-rabbitmq
 
 Usage:
-    zabbix-agent-extension-rabbitmq [-r <address>] [-u <name>] [-s <password>] [-c <path>] [-z <host>] [-p <number>] [-o <name>] [-t <timeout>] [-d [-g <name>] [-a]]
+    zabbix-agent-extension-rabbitmq [-r <address>] [-u <name>] [-s <password>] [-t <timeout>] [-c <path>] [-z <host>] [-p <number>] [-o <name>] [-d [-g <name>] [-a]]
 
 RabbitMQ options:
     -r --rabbitmq <address>          Listen address of RabbitMQ server [default: http://127.0.0.1:15672]

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	zsend "github.com/blacked/go-zabbix"
 	docopt "github.com/docopt/docopt-go"
@@ -25,7 +26,7 @@ RabbitMQ options:
     -r --rabbitmq <address>          Listen address of RabbitMQ server [default: http://127.0.0.1:15672]
     -u --rabbitmq-user <name>        RabbitMQ management username [default: guest]
     -s --rabbitmq-secret <password>  RabbitMQ management password [default: guest]
-    -t --rabbitmq-timeout <timeout>  RabbitMQ request timeout in ms [default: 5000]
+    -t --rabbitmq-timeout <timeout>  RabbitMQ request timeout in ms [default: 5000ms]
     -c --ca <path>                   Path to CA file. [default: ` + noneValue + `]
 
 Zabbix options:
@@ -57,7 +58,7 @@ Misc options:
 		os.Exit(1)
 	}
 
-	rmqTimeout, err := strconv.Atoi(args["--rabbitmq-timeout"].(string))
+	rmqTimeout, err := time.ParseDuration(args["--rabbitmq-timeout"].(string))
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -24,8 +24,8 @@ Usage:
 RabbitMQ options:
     -r --rabbitmq <address>          Listen address of RabbitMQ server [default: http://127.0.0.1:15672]
     -u --rabbitmq-user <name>        RabbitMQ management username [default: guest]
-	-s --rabbitmq-secret <password>  RabbitMQ management password [default: guest]
-	-t --rabbitmq-timeout <timeout>  RabbitMQ request timeout in ms [default: 5000]
+    -s --rabbitmq-secret <password>  RabbitMQ management password [default: guest]
+    -t --rabbitmq-timeout <timeout>  RabbitMQ request timeout in ms [default: 5000]
     -c --ca <path>                   Path to CA file. [default: ` + noneValue + `]
 
 Zabbix options:

--- a/main.go
+++ b/main.go
@@ -19,12 +19,13 @@ func main() {
 	usage := `zabbix-agent-extension-rabbitmq
 
 Usage:
-    zabbix-agent-extension-rabbitmq [-r <address>] [-u <name>] [-s <password>] [-c <path>] [-z <host>] [-p <number>] [-o <name>] [-d [-g <name>] [-a]]
+    zabbix-agent-extension-rabbitmq [-r <address>] [-u <name>] [-s <password>] [-c <path>] [-z <host>] [-p <number>] [-o <name>] [-t <timeout>] [-d [-g <name>] [-a]]
 
 RabbitMQ options:
     -r --rabbitmq <address>          Listen address of RabbitMQ server [default: http://127.0.0.1:15672]
     -u --rabbitmq-user <name>        RabbitMQ management username [default: guest]
-    -s --rabbitmq-secret <password>  RabbitMQ management password [default: guest]
+	-s --rabbitmq-secret <password>  RabbitMQ management password [default: guest]
+	-t --rabbitmq-timeout <timeout>  RabbitMQ request timeout in ms [default: 5000]
     -c --ca <path>                   Path to CA file. [default: ` + noneValue + `]
 
 Zabbix options:
@@ -56,6 +57,12 @@ Misc options:
 		os.Exit(1)
 	}
 
+	rmqTimeout, err := strconv.Atoi(args["--rabbitmq-timeout"].(string))
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
 	var metrics []*zsend.Metric
 
 	hostname := args["--hostname"].(string)
@@ -65,6 +72,7 @@ Misc options:
 		args["--rabbitmq-user"].(string),
 		args["--rabbitmq-secret"].(string),
 		args["--ca"].(string),
+		rmqTimeout,
 	)
 	if err != nil {
 		fmt.Println(err.Error())

--- a/tools.go
+++ b/tools.go
@@ -40,7 +40,7 @@ func makeRabbitMQClient(
 	username string,
 	password string,
 	caPath string,
-	timeout int,
+	timeout time.Duration,
 ) (*rabbithole.Client, error) {
 	destiny := karma.Describe(
 		"method", "makeRabbitMQClient",
@@ -69,7 +69,7 @@ func makeRabbitMQClient(
 			)
 		}
 
-		rmqc.SetTimeout(time.Duration(timeout) * time.Millisecond)
+		rmqc.SetTimeout(timeout)
 
 		return rmqc, nil
 	}
@@ -127,7 +127,7 @@ func makeRabbitMQClient(
 
 	}
 
-	rmqc.SetTimeout(time.Duration(timeout) * time.Millisecond)
+	rmqc.SetTimeout(timeout)
 
 	return rmqc, nil
 }

--- a/tools.go
+++ b/tools.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole"
 	"github.com/reconquest/karma-go"
@@ -39,6 +40,7 @@ func makeRabbitMQClient(
 	username string,
 	password string,
 	caPath string,
+	timeout int,
 ) (*rabbithole.Client, error) {
 	destiny := karma.Describe(
 		"method", "makeRabbitMQClient",
@@ -66,6 +68,8 @@ func makeRabbitMQClient(
 				"can't create RabbitMQ client",
 			)
 		}
+
+		rmqc.SetTimeout(time.Duration(timeout) * time.Millisecond)
 
 		return rmqc, nil
 	}
@@ -122,6 +126,8 @@ func makeRabbitMQClient(
 		)
 
 	}
+
+	rmqc.SetTimeout(time.Duration(timeout) * time.Millisecond)
 
 	return rmqc, nil
 }


### PR DESCRIPTION
If it's possible to establish a tcp connection with RabbitMQ server but it does not send a data response, connection will hang and Zabbix items will go into unsupported mode. 

This feature will add option to set timeout value and default will be 5000ms.

